### PR TITLE
add NaiveGN

### DIFF
--- a/adet/layers/__init__.py
+++ b/adet/layers/__init__.py
@@ -2,5 +2,6 @@ from .deform_conv import DFConv2d
 from .ml_nms import ml_nms
 from .iou_loss import IOULoss
 from .conv_with_kaiming_uniform import conv_with_kaiming_uniform
+from .naive_group_norm import NaiveGroupNorm
 
 __all__ = [k for k in globals().keys() if not k.startswith("_")]

--- a/adet/layers/naive_group_norm.py
+++ b/adet/layers/naive_group_norm.py
@@ -1,0 +1,74 @@
+import torch
+from torch.nn import Module, Parameter
+from torch.nn import init
+
+
+class NaiveGroupNorm(Module):
+    r"""NaiveGroupNorm implements Group Normalization with the high-level matrix operations in PyTorch.
+    It is a temporary solution to export GN by ONNX before the official GN can be exported by ONNX.
+    The usage of NaiveGroupNorm is exactly the same as the official :class:`torch.nn.GroupNorm`.
+    Args:
+        num_groups (int): number of groups to separate the channels into
+        num_channels (int): number of channels expected in input
+        eps: a value added to the denominator for numerical stability. Default: 1e-5
+        affine: a boolean value that when set to ``True``, this module
+            has learnable per-channel affine parameters initialized to ones (for weights)
+            and zeros (for biases). Default: ``True``.
+
+    Shape:
+        - Input: :math:`(N, C, *)` where :math:`C=\text{num\_channels}`
+        - Output: :math:`(N, C, *)` (same shape as input)
+
+    Examples::
+
+        >>> input = torch.randn(20, 6, 10, 10)
+        >>> # Separate 6 channels into 3 groups
+        >>> m = NaiveGroupNorm(3, 6)
+        >>> # Separate 6 channels into 6 groups (equivalent with InstanceNorm)
+        >>> m = NaiveGroupNorm(6, 6)
+        >>> # Put all 6 channels into a single group (equivalent with LayerNorm)
+        >>> m = NaiveGroupNorm(1, 6)
+        >>> # Activating the module
+        >>> output = m(input)
+
+    .. _`Group Normalization`: https://arxiv.org/abs/1803.08494
+    """
+    __constants__ = ['num_groups', 'num_channels', 'eps', 'affine', 'weight',
+                     'bias']
+
+    def __init__(self, num_groups, num_channels, eps=1e-5, affine=True):
+        super(NaiveGroupNorm, self).__init__()
+        self.num_groups = num_groups
+        self.num_channels = num_channels
+        self.eps = eps
+        self.affine = affine
+        if self.affine:
+            self.weight = Parameter(torch.Tensor(num_channels))
+            self.bias = Parameter(torch.Tensor(num_channels))
+        else:
+            self.register_parameter('weight', None)
+            self.register_parameter('bias', None)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.affine:
+            init.ones_(self.weight)
+            init.zeros_(self.bias)
+
+    def forward(self, input):
+        N, C, H, W = input.size()
+        assert C % self.num_groups == 0
+        input = input.reshape(N, self.num_groups, -1)
+        mean = input.mean(dim=-1, keepdim=True)
+        var = (input ** 2).mean(dim=-1, keepdim=True) - mean ** 2
+        std = torch.sqrt(var + self.eps)
+
+        input = (input - mean) / std
+        input = input.reshape(N, C, H, W)
+        if self.affine:
+            input = input * self.weight.reshape(1, C, 1, 1) + self.bias.reshape(1, C, 1, 1)
+        return input
+
+    def extra_repr(self):
+        return '{num_groups}, {num_channels}, eps={eps}, ' \
+            'affine={affine}'.format(**self.__dict__)

--- a/adet/modeling/fcos/fcos.py
+++ b/adet/modeling/fcos/fcos.py
@@ -7,7 +7,7 @@ from torch.nn import functional as F
 from detectron2.layers import ShapeSpec
 from detectron2.modeling.proposal_generator.build import PROPOSAL_GENERATOR_REGISTRY
 
-from adet.layers import DFConv2d, IOULoss
+from adet.layers import DFConv2d, IOULoss, NaiveGroupNorm
 from .fcos_outputs import FCOSOutputs
 
 
@@ -179,6 +179,8 @@ class FCOSHead(nn.Module):
                 ))
                 if norm == "GN":
                     tower.append(nn.GroupNorm(32, in_channels))
+                elif norm == "NaiveGN":
+                    tower.append(NaiveGroupNorm(32, in_channels))
                 tower.append(nn.ReLU())
             self.add_module('{}_tower'.format(head),
                             nn.Sequential(*tower))


### PR DESCRIPTION
Add `NaiveGroupNorm`, which implements GN by the matrix operations in PyTorch and can be exported by ONNX. To enable, please set `MODEL.FCOS.NORM` as `NaiveGN`.