### PR TITLE
Add the support of exporting model to ONNX

### DIFF
--- a/adet/modeling/fcos/fcos.py
+++ b/adet/modeling/fcos/fcos.py
@@ -150,6 +150,7 @@ class FCOSHead(nn.Module):
         """
         super().__init__()
         # TODO: Implement the sigmoid version first.
+        self.in_features = cfg.MODEL.FCOS.IN_FEATURES
         self.num_classes = cfg.MODEL.FCOS.NUM_CLASSES
         self.fpn_strides = cfg.MODEL.FCOS.FPN_STRIDES
         head_configs = {"cls": (cfg.MODEL.FCOS.NUM_CLS_CONVS,
@@ -217,7 +218,12 @@ class FCOSHead(nn.Module):
         bias_value = -math.log((1 - prior_prob) / prior_prob)
         torch.nn.init.constant_(self.cls_logits.bias, bias_value)
 
+        # for export
+        self.onnx_export = False
+
     def forward(self, x):
+        if self.onnx_export:
+            x = [x[f] for f in self.in_features]
         logits = []
         bbox_reg = []
         ctrness = []

--- a/configs/FCOS-Detection/R_50_1x.yaml
+++ b/configs/FCOS-Detection/R_50_1x.yaml
@@ -3,8 +3,6 @@ MODEL:
   WEIGHTS: "detectron2://ImageNetPretrained/MSRA/R-50.pkl"
   RESNETS:
     DEPTH: 50
-  FCOS:
-    NORM: NaiveGN
 INPUT:
   MIN_SIZE_TRAIN: (800,)
 SOLVER:

--- a/configs/FCOS-Detection/R_50_1x.yaml
+++ b/configs/FCOS-Detection/R_50_1x.yaml
@@ -3,6 +3,8 @@ MODEL:
   WEIGHTS: "detectron2://ImageNetPretrained/MSRA/R-50.pkl"
   RESNETS:
     DEPTH: 50
+  FCOS:
+    NORM: NaiveGN
 INPUT:
   MIN_SIZE_TRAIN: (800,)
 SOLVER:

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -7,6 +7,13 @@ import time
 import cv2
 import tqdm
 
+try:
+    from remove_python_path import remove_path
+    remove_path()
+except:
+    import sys
+    print(sys.path)
+
 from detectron2.data.detection_utils import read_image
 from detectron2.utils.logger import setup_logger
 

--- a/onnx/export_model_to_onnx.py
+++ b/onnx/export_model_to_onnx.py
@@ -72,8 +72,9 @@ def main():
     # norm for ONNX: change FrozenBN back to BN
     cfg.MODEL.BACKBONE.FREEZE_AT = 0
     cfg.MODEL.RESNETS.NORM = "BN"
-    # turn on the following?
+    # turn on the following configuration according to your own convenience, default: NaiveGN
     #cfg.MODEL.FCOS.NORM = "BN"
+    cfg.MODEL.FCOS.NORM = "NaiveGN"
     cfg.freeze()
 
     output_dir = cfg.OUTPUT_DIR

--- a/onnx/export_model_to_onnx.py
+++ b/onnx/export_model_to_onnx.py
@@ -1,0 +1,129 @@
+"""
+Please make sure you are using pytorch >= 1.4.0 (or nightly).
+A working example to export the R-50 based FCOS model:
+python onnx/export_model_to_onnx.py \
+    --config-file configs/FCOS-Detection/R_50_1x.yaml \
+    MODEL.WEIGHT weights/fcos_R_50_1x.pth
+
+"""
+
+import argparse
+import os
+import glob
+import multiprocessing as mp
+import os
+import time
+import cv2
+import tqdm
+
+try:
+    from remove_python_path import remove_path
+    remove_path()
+except:
+    import sys
+    print(sys.path)
+
+import torch
+from detectron2.data.detection_utils import read_image
+from detectron2.utils.logger import setup_logger
+from detectron2.data import MetadataCatalog
+from detectron2.modeling import build_model
+from detectron2.checkpoint import DetectionCheckpointer
+from collections import OrderedDict
+
+from adet.config import get_cfg
+
+def main():
+    parser = argparse.ArgumentParser(description="Export model to the onnx format")
+    parser.add_argument(
+        "--config-file",
+        default="configs/FCOS-Detection/R_50_1x.yaml",
+        metavar="FILE",
+        help="path to config file",
+    )
+    parser.add_argument(
+        "--output",
+        default="output/fcos.onnx",
+        metavar="FILE",
+        help="path to the output onnx file",
+    )
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.5,
+        help="Minimum score for instance predictions to be shown",
+    )
+    parser.add_argument(
+        "--opts",
+        help="Modify config options using the command-line 'KEY VALUE' pairs",
+        default=[],
+        nargs=argparse.REMAINDER,
+    )
+
+    cfg = get_cfg()
+    args = parser.parse_args()
+    cfg.merge_from_file(args.config_file)
+    cfg.merge_from_list(args.opts)
+    # Set score_threshold for builtin models
+    cfg.MODEL.RETINANET.SCORE_THRESH_TEST = args.confidence_threshold
+    cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = args.confidence_threshold
+    cfg.MODEL.FCOS.INFERENCE_TH_TEST = args.confidence_threshold
+    cfg.MODEL.PANOPTIC_FPN.COMBINE.INSTANCES_CONFIDENCE_THRESH = args.confidence_threshold
+    # norm for ONNX: change FrozenBN back to BN
+    cfg.MODEL.BACKBONE.FREEZE_AT = 0
+    cfg.MODEL.RESNETS.NORM = "BN"
+    # turn on the following?
+    #cfg.MODEL.FCOS.NORM = "BN"
+    cfg.freeze()
+
+    output_dir = cfg.OUTPUT_DIR
+    logger = setup_logger(output=output_dir)
+    logger.info(cfg)
+
+    if cfg.MODEL.FCOS.NORM == "GN":
+        logger.info('warning: onnx current not support GroupNorm fully')
+
+    model = build_model(cfg)
+    model.eval()
+    model.to(cfg.MODEL.DEVICE)
+    logger.info("Model:\n{}".format(model))
+
+    checkpointer = DetectionCheckpointer(model)
+    _ = checkpointer.load(cfg.MODEL.WEIGHTS)
+
+    if hasattr(model.proposal_generator.fcos_head, 'onnx_export'):
+        model.proposal_generator.fcos_head.onnx_export = True
+        logger.info("Update : model.proposal_generator.fcos_head.onnx_export to be True")
+
+    onnx_model = torch.nn.Sequential(OrderedDict([
+        ('backbone', model.backbone),
+        ('heads', model.proposal_generator.fcos_head),
+    ]))
+
+    height, width = 800, 1216
+    input_names = ["input_image"]
+    dummy_input = torch.zeros((1, 3, height, width)).to(cfg.MODEL.DEVICE)
+    output_names = []
+    for l in range(len(cfg.MODEL.FCOS.FPN_STRIDES)):
+        fpn_name = "P{}/".format(3 + l)
+        output_names.extend([
+            fpn_name + "logits",
+            fpn_name + "bbox_reg",
+            fpn_name + "centerness"
+        ])
+
+    torch.onnx.export(
+        onnx_model,
+        dummy_input,
+        args.output,
+        verbose=True,
+        input_names=input_names,
+        output_names=output_names,
+        keep_initializers_as_inputs=True
+    )
+
+    logger.info("Done. The onnx model is saved into {}.".format(args.output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
usage:
python onnx/export_model_to_onnx.py --config-file configs/FCOS-Detection/R_50_1x.yaml --opts MODEL.WEIGHT weights/fcos_R_50_1x.pth

note:
It's better to change all GroupNorm to BatchnNorm, as the GN is not well supported by ONNX yet. Besides, it costs extra computing resources in the inference.


 
