### PR TITLE
Fix mapper argument for build_detection_train_loader

### DIFF
--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -100,7 +100,7 @@ class Trainer(DefaultTrainer):
         DatasetMapper, which adds categorical labels as a semantic mask.
         """
         mapper = DatasetMapperWithBasis(cfg, True)
-        return build_detection_train_loader(cfg, mapper)
+        return build_detection_train_loader(cfg, mapper=mapper)
 
     @classmethod
     def build_evaluator(cls, cfg, dataset_name, output_folder=None):


### PR DESCRIPTION
**Problem**
Not able to use train_net.py with the latest Detectron2 on Google Colab due to the fact that the positional argument (mapper) is provided instead of keyword argument. 

**Environment**
detectron2: 0.3
CUDA: 10.1
torch: 1.7.0

**Error**
```
Traceback (most recent call last):
  File "tools/train_net.py", line 218, in <module>
    args=(args,),
  File "/usr/local/lib/python3.6/dist-packages/detectron2/engine/launch.py", line 62, in launch
    main_func(*args)
  File "tools/train_net.py", line 200, in main
    trainer = Trainer(cfg)
  File "/usr/local/lib/python3.6/dist-packages/detectron2/engine/defaults.py", line 284, in __init__
    data_loader = self.build_train_loader(cfg)
  File "tools/train_net.py", line 103, in build_train_loader
    return build_detection_train_loader(cfg, mapper)
  File "/usr/local/lib/python3.6/dist-packages/detectron2/config/config.py", line 201, in wrapped
    explicit_args = _get_args_from_config(from_config, *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/detectron2/config/config.py", line 236, in _get_args_from_config
    ret = from_config_func(*args, **kwargs)
TypeError: _train_loader_from_config() takes 1 positional argument but 2 were given
```