### PR TITLE
replace python-Levenshtein

### DIFF
--- a/adet/evaluation/text_eval_script.py
+++ b/adet/evaluation/text_eval_script.py
@@ -8,7 +8,7 @@ import sys
 
 import math 
 
-import Levenshtein as lstn
+from rapidfuzz import string_metric
 
 WORD_SPOTTING =True
 def evaluation_imports():
@@ -378,7 +378,7 @@ def evaluate_method(gtFilePath, submFilePath, evaluationParams):
                                 # det_only_correct = True
                                 # detOnlyCorrect += 1
                                 if evaluationParams['WORD_SPOTTING']:
-                                    edd = lstn.distance(gtTrans[gtNum].upper(), detTrans[detNum].upper())
+                                    edd = string_metric.levenshtein(gtTrans[gtNum].upper(), detTrans[detNum].upper())
                                     if edd<=0: 
                                         correct = True
                                     else:

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "matplotlib",
         "tqdm>4.29.0",
         "tensorboard",
-        "python-Levenshtein",
+        "rapidfuzz",
         "Polygon3",
         "shapely",
     ],


### PR DESCRIPTION
Python-Levenshtein is GPL Licensed, which is incompatible with the license used by this project. This Pull Request replaces python-Levenshtein with RapidFuzz, which is licensed in a compatible way (MIT License).