### PR TITLE
A code enhancement on #380 and #379

### DIFF
--- a/adet/config/defaults.py
+++ b/adet/config/defaults.py
@@ -65,6 +65,7 @@ _C.MODEL.FCOS.CENTER_SAMPLE = True
 _C.MODEL.FCOS.POS_RADIUS = 1.5
 _C.MODEL.FCOS.LOC_LOSS_TYPE = 'giou'
 _C.MODEL.FCOS.YIELD_PROPOSAL = False
+_C.MODEL.FCOS.YIELD_BOX_FEATURES = False
 
 # ---------------------------------------------------------------------------- #
 # VoVNet backbone


### PR DESCRIPTION
https://github.com/aim-uofa/AdelaiDet/blob/a0a6adb2dd54a7c523cdfcf86239cdbc3132b592/adet/modeling/fcos/fcos.py#L79-L108

Hi @tianzhi0549, I guess that the code above (before PR #380) was originally used to return box regression features in `results` to external modules for post-processing if necessary. So, if I'm right, I mistakenly removed this feature in PR #380.
So I fix this bug with a new PR. Thanks!