### PR TITLE
fix TypeError bug in #397

### DIFF
--- a/adet/modeling/fcos/fcos.py
+++ b/adet/modeling/fcos/fcos.py
@@ -93,19 +93,22 @@ class FCOS(nn.Module):
                         logits_pred, reg_pred, ctrness_pred,
                         locations, images.image_sizes, top_feats
                     )
+            if self.yield_box_feats:
+                results["box_feats"] = {
+                    f: b for f, b in zip(self.in_features, bbox_towers)
+                }
+            return results, losses
         else:
             results = self.fcos_outputs.predict_proposals(
                 logits_pred, reg_pred, ctrness_pred,
                 locations, images.image_sizes, top_feats
             )
-            losses = {}
-
-        if self.yield_box_feats:
-            results["box_feats"] = {
-                f: b for f, b in zip(self.in_features, bbox_towers)
-            }
-
-        return results, losses
+            extras = {}
+            if self.yield_box_feats:
+                extras["box_feats"] = {
+                    f: b for f, b in zip(self.in_features, bbox_towers)
+                }
+            return results, extras
 
     def compute_locations(self, features):
         locations = []


### PR DESCRIPTION
#397 introduced a TypeError bug as `results` returned by `self.fcos_outputs.predict_proposals()` is a list during testing, whereas `results` returned by `self.fcos_outputs.losses()` is a dict during training.