### PR TITLE
fix build bug with pytorch>=1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,11 @@ def get_extensions():
             "-D__CUDA_NO_HALF2_OPERATORS__",
         ]
 
-    if torch_ver < [1, 7]:
-        # supported by https://github.com/pytorch/pytorch/pull/43931
-        CC = os.environ.get("CC", None)
-        if CC is not None:
-            extra_compile_args["nvcc"].append("-ccbin={}".format(CC))
+        if torch_ver < [1, 7]:
+            # supported by https://github.com/pytorch/pytorch/pull/43931
+            CC = os.environ.get("CC", None)
+            if CC is not None:
+                extra_compile_args["nvcc"].append("-ccbin={}".format(CC))
 
     sources = [os.path.join(extensions_dir, s) for s in sources]
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ def get_extensions():
             "-D__CUDA_NO_HALF2_OPERATORS__",
         ]
 
-        # It's better if pytorch can do this by default ..
+    if torch_ver < [1, 7]:
+        # supported by https://github.com/pytorch/pytorch/pull/43931
         CC = os.environ.get("CC", None)
         if CC is not None:
             extra_compile_args["nvcc"].append("-ccbin={}".format(CC))


### PR DESCRIPTION
When I try to build AdelaiDet with pytorch==1.7, nvcc=9.2 and gcc==5.4, I get a compiling error `nvcc fatal : redefinition of argument 'compiler-bindir'`.
After changing few lines of `setup.py` following Detectron2, AdelaiDet is built successfully.