### PR TITLE
Enable to resume training again

### DIFF
--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -20,6 +20,7 @@ import os
 from collections import OrderedDict
 import torch
 from torch.nn.parallel import DistributedDataParallel
+from fvcore.nn.precise_bn import get_bn_modules
 
 import detectron2.utils.comm as comm
 from detectron2.data import MetadataCatalog, build_detection_train_loader
@@ -48,16 +49,66 @@ class Trainer(DefaultTrainer):
     This is the same Trainer except that we rewrite the
     `build_train_loader`/`resume_or_load` method.
     """
-    def resume_or_load(self, resume=True):
-        if not isinstance(self.checkpointer, AdetCheckpointer):
-            # support loading a few other backbones
-            self.checkpointer = AdetCheckpointer(
+    def build_hooks(self):
+        """
+        This method is originally from `DefaultTrainer` and we replace 
+        `DetectionCheckpointer` with `AdetCheckpointer`.
+        
+        Build a list of default hooks, including timing, evaluation,
+        checkpointing, lr scheduling, precise BN, writing events.
+        """
+        cfg = self.cfg.clone()
+        cfg.defrost()
+        cfg.DATALOADER.NUM_WORKERS = 0  # save some memory and time for PreciseBN
+
+        ret = [
+            hooks.IterationTimer(),
+            hooks.LRScheduler(),
+            hooks.PreciseBN(
+                # Run at the same freq as (but before) evaluation.
+                cfg.TEST.EVAL_PERIOD,
                 self.model,
-                self.cfg.OUTPUT_DIR,
-                optimizer=self.optimizer,
-                scheduler=self.scheduler,
+                # Build a new data loader to not affect training
+                self.build_train_loader(cfg),
+                cfg.TEST.PRECISE_BN.NUM_ITER,
             )
-        super().resume_or_load(resume=resume)
+            if cfg.TEST.PRECISE_BN.ENABLED and get_bn_modules(self.model)
+            else None,
+        ]
+
+        # Do PreciseBN before checkpointer, because it updates the model and need to
+        # be saved by checkpointer.
+        # This is not always the best: if checkpointing has a different frequency,
+        # some checkpoints may have more precise statistics than others.
+        if comm.is_main_process():
+            if not isinstance(self.checkpointer, AdetCheckpointer):
+                # support loading a few other backbones
+                self.checkpointer = AdetCheckpointer(
+                    self.model,
+                    self.cfg.OUTPUT_DIR,
+                    optimizer=self.optimizer,
+                    scheduler=self.scheduler,
+                )
+            ret.append(hooks.PeriodicCheckpointer(self.checkpointer, cfg.SOLVER.CHECKPOINT_PERIOD))
+
+        def test_and_save_results():
+            self._last_eval_results = self.test(self.cfg, self.model)
+            return self._last_eval_results
+
+        # Do evaluation after checkpointer, because then if it fails,
+        # we can use the saved checkpoint to debug.
+        ret.append(hooks.EvalHook(cfg.TEST.EVAL_PERIOD, test_and_save_results))
+
+        if comm.is_main_process():
+            # Here the default print/log frequency of each writer is used.
+            # run writers in the end, so that evaluation metrics are written
+            ret.append(hooks.PeriodicWriter(self.build_writers(), period=20))
+        return ret
+    
+    def resume_or_load(self, resume=True):
+        checkpoint = self.checkpointer.resume_or_load(self.cfg.MODEL.WEIGHTS, resume=resume)
+        if resume and self.checkpointer.has_checkpoint():
+            self.start_iter = checkpoint.get("iteration", -1) + 1
 
     def train_loop(self, start_iter: int, max_iter: int):
         """

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -20,7 +20,6 @@ import os
 from collections import OrderedDict
 import torch
 from torch.nn.parallel import DistributedDataParallel
-from fvcore.nn.precise_bn import get_bn_modules
 
 import detectron2.utils.comm as comm
 from detectron2.data import MetadataCatalog, build_detection_train_loader
@@ -51,58 +50,21 @@ class Trainer(DefaultTrainer):
     """
     def build_hooks(self):
         """
-        This method is originally from `DefaultTrainer` and we replace 
-        `DetectionCheckpointer` with `AdetCheckpointer`.
-        
+        Replace `DetectionCheckpointer` with `AdetCheckpointer`.
+
         Build a list of default hooks, including timing, evaluation,
         checkpointing, lr scheduling, precise BN, writing events.
         """
-        cfg = self.cfg.clone()
-        cfg.defrost()
-        cfg.DATALOADER.NUM_WORKERS = 0  # save some memory and time for PreciseBN
-
-        ret = [
-            hooks.IterationTimer(),
-            hooks.LRScheduler(),
-            hooks.PreciseBN(
-                # Run at the same freq as (but before) evaluation.
-                cfg.TEST.EVAL_PERIOD,
-                self.model,
-                # Build a new data loader to not affect training
-                self.build_train_loader(cfg),
-                cfg.TEST.PRECISE_BN.NUM_ITER,
-            )
-            if cfg.TEST.PRECISE_BN.ENABLED and get_bn_modules(self.model)
-            else None,
-        ]
-
-        # Do PreciseBN before checkpointer, because it updates the model and need to
-        # be saved by checkpointer.
-        # This is not always the best: if checkpointing has a different frequency,
-        # some checkpoints may have more precise statistics than others.
-        if comm.is_main_process():
-            if not isinstance(self.checkpointer, AdetCheckpointer):
-                # support loading a few other backbones
+        ret = super().build_hooks()
+        for i in range(len(ret)):
+            if isinstance(ret[i], hooks.PeriodicCheckpointer):
                 self.checkpointer = AdetCheckpointer(
                     self.model,
                     self.cfg.OUTPUT_DIR,
                     optimizer=self.optimizer,
                     scheduler=self.scheduler,
                 )
-            ret.append(hooks.PeriodicCheckpointer(self.checkpointer, cfg.SOLVER.CHECKPOINT_PERIOD))
-
-        def test_and_save_results():
-            self._last_eval_results = self.test(self.cfg, self.model)
-            return self._last_eval_results
-
-        # Do evaluation after checkpointer, because then if it fails,
-        # we can use the saved checkpoint to debug.
-        ret.append(hooks.EvalHook(cfg.TEST.EVAL_PERIOD, test_and_save_results))
-
-        if comm.is_main_process():
-            # Here the default print/log frequency of each writer is used.
-            # run writers in the end, so that evaluation metrics are written
-            ret.append(hooks.PeriodicWriter(self.build_writers(), period=20))
+                ret[i] = hooks.PeriodicCheckpointer(self.checkpointer, self.cfg.SOLVER.CHECKPOINT_PERIOD)
         return ret
     
     def resume_or_load(self, resume=True):


### PR DESCRIPTION
Summary:
The `Trainer` rewrite the `resume_or_load` method to apply `AdetCheckpointer`.However,the `Trainer` builds 
and registers hooks when `Trainer` object being initialized, that is to say,the checkpointer actually uses `DetectionCheckpointer` rather than `AdetCheckpointer`.

Recently detectron2 has modified the initial kwargs parameters of `DetectionCheckpointer` in  `detectron2/engine/defaults.py`. Code is [here](https://github.com/facebookresearch/detectron2/commit/085be5a3e470ccef8c44ca738cab666f37007487#diff-0b29aacf4e6259b903bb8a9a2c5a02a61f112185047f1963e492431042734c7bL373)


In this situation AdelaiDet can not resume training and I solve the bug by:
1.Rewriting `resume_and_load`.Make sure the model can be resumed with the right iteration.
2.Rewriting `build_hooks`. Replace `DetectionCheckpointer` with  `AdetCheckpointer` for checkpoint.