### PR TITLE
fix bug: set adet as parent logger

### DIFF
--- a/tools/visualize_data.py
+++ b/tools/visualize_data.py
@@ -49,7 +49,7 @@ def parse_args(in_args=None):
 
 if __name__ == "__main__":
     args = parse_args()
-    logger = setup_logger()
+    logger = setup_logger(name='adet')
     logger.info("Arguments: " + str(args))
     cfg = setup(args)
 


### PR DESCRIPTION
When running `tools/visualize_data.py`, since the logger whose name is adet is not set, the parent loggers of all the submodules of `adet` are root logger, which causes the `INFO` level log to not be output.  
Please see #586 for detail.  