### PR TITLE
fix recording bug in after_train function

### DIFF
--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -67,7 +67,7 @@ class Trainer(DefaultTrainer):
                 )
                 ret[i] = hooks.PeriodicCheckpointer(self.checkpointer, self.cfg.SOLVER.CHECKPOINT_PERIOD)
         return ret
-    
+
     def resume_or_load(self, resume=True):
         checkpoint = self.checkpointer.resume_or_load(self.cfg.MODEL.WEIGHTS, resume=resume)
         if resume and self.checkpointer.has_checkpoint():
@@ -90,6 +90,7 @@ class Trainer(DefaultTrainer):
                 self.before_step()
                 self.run_step()
                 self.after_step()
+            self.iter += 1
             self.after_train()
 
     def train(self):


### PR DESCRIPTION
When I evaluate model in the `after_train` function and record results, the result will not be recorded in `Tensorboard` and `metrics.json`

This is because detectron2.utils.events.`TensorboardXWriter` and `JSONWriter` will check the `trainer.iter`, and each iter will only record once.
If you do not set `trainer.iter+1` before executing `after_train`, the execution result will not be recorded, because the current trainer.iter has been used in the last step

So I fixed this issue in `train_loop` function
